### PR TITLE
Change in core.create to allow an object as source

### DIFF
--- a/js/jquery.fn.gantt.js
+++ b/js/jquery.fn.gantt.js
@@ -119,11 +119,20 @@
 				/**
 				 * Retrieve data
 				 */
-				$.ajaxSetup({ scriptCharset: "utf-8" , contentType: "application/json; charset=utf-8"});
-				$.getJSON(settings.source, function(jsData) {
-					element.data = jsData;
+				if(typeof(settings.source) == 'object'){
+					
+					element.data = settings.source;
 					core.init(element);
-				});
+ 	
+				} else {
+				 
+					$.ajaxSetup({ scriptCharset: "utf-8" , contentType: "application/json; charset=utf-8"});
+					$.getJSON(settings.source, function(jsData) {
+						element.data = jsData;
+						core.init(element);
+					});
+				}
+
 			},
 			init: function (element) {
 					element.rowsNum = element.data.length;


### PR DESCRIPTION
The change in core.create function allow to load a JS object as source. This allow dynamic chart generation (e.g. from an existing html list or table)
